### PR TITLE
postgresql: /usr/include/libpq-fe.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,12 @@ check_include_file_cxx(postgresql/libpq-fe.h HAS_POSTGRES)
 if (HAS_POSTGRES)
     add_definitions(-DHAS_POSTGRES)
 else()
-    message("No libpq-fe.h file found. Postgres driver disabled")
+    check_include_file_cxx(libpq-fe.h HAS_POSTGRES)
+    if (HAS_POSTGRES)
+        add_definitions(-DHAS_POSTGRES)
+    else()
+        message("No libpq-fe.h file found. Postgres driver disabled")
+    endif()
 endif()
 
 


### PR DESCRIPTION
check also if libpq-fe.h on /usr/include/, in my case I have this header on /usr/include/ and not /usr/include/postgresql (Slackware).